### PR TITLE
fix: 使用 MarkdownRenderer 优化导出预览渲染

### DIFF
--- a/src/components/file/ModalContent.tsx
+++ b/src/components/file/ModalContent.tsx
@@ -10,8 +10,6 @@ import Target, { type TargetRef } from '../common/Target';
 import FormItems from '../common/form/FormItems';
 import { type CSSFileInfo, getCSSFiles, readCSSFile } from '../../utils/cssLoader';
 
-
-
 const ModalContent: FC<{
   markdownEl: Node;
   settings: ISettings;
@@ -248,12 +246,6 @@ const ModalContent: FC<{
     },
   ], [cssFiles]);
 
-  // 添加日志检查函数
-  useEffect(() => {
-    console.log("ModalContent rendered, loading state:", isLoading);
-    console.log("markdownEl content:", markdownEl instanceof HTMLElement ? markdownEl.innerHTML.substring(0, 100) + "..." : "Not HTML Element");
-  }, [isLoading, markdownEl]);
-
   const calculateScale = useCallback(() => {
     if (!root.current?.element || !previewOutRef.current) return 1;
     const contentHeight = root.current.element.clientHeight;
@@ -302,7 +294,6 @@ const ModalContent: FC<{
     });
   }, [formData.format]);
 
-  // 加载 CSS 文件列表
   useEffect(() => {
     if (formData.customCSS?.src) {
       getCSSFiles(app, formData.customCSS.src).then(files => {
@@ -313,7 +304,6 @@ const ModalContent: FC<{
     }
   }, [app, formData.customCSS?.src]);
 
-  // 读取选中的 CSS 文件内容
   useEffect(() => {
     const cssPath = formData.customCSS?.css;
     if (cssPath) {

--- a/src/components/file/exportImage.tsx
+++ b/src/components/file/exportImage.tsx
@@ -30,7 +30,7 @@ export default async function (
   // 创建元素和模态框先
   const el = document.createElement('div');
   const skipConfig = type === 'selection' && settings.quickExportSelection;
-  
+
   // 如果是快速导出，创建隐藏的div元素进行处理
   if (skipConfig) {
     const div = createDiv();
@@ -51,10 +51,10 @@ export default async function (
         app={app}
       />,
     );
-    
+
     // 先打开模态框，再加载内容
-    await loadDocumentContent(app, el);
-    
+    await loadDocumentContent(app, el, markdown, file);
+
     try {
       await copy(div.querySelector('.export-image-root')!, settings.resolutionMode, settings.format);
     } catch (e) {
@@ -73,10 +73,10 @@ export default async function (
     modal.modalEl.style.maxWidth = '1500px';
     modal.open();
     const root = createRoot(modal.contentEl);
-    
+
     /* @ts-ignore */
     const metadataMap: Record<string, { type: MetadataType }> = app.metadataCache.getAllPropertyInfos();
-    
+
     // 渲染组件，组件内部会处理loading状态
     root.render(
       <ModalContent
@@ -88,87 +88,49 @@ export default async function (
         app={app}
       />,
     );
-    
+
     // 异步加载文档内容
-    await loadDocumentContent(app, el);
-    
+    await loadDocumentContent(app, el, markdown, file);
+
     // 发布一个自定义事件，通知内容已加载完成
     const loadedEvent = new CustomEvent("export-image-content-loaded");
     window.document.dispatchEvent(loadedEvent);
-    
+
     modal.onClose = () => {
       root?.unmount();
     };
   }
 }
 
-// 提取加载文档内容的函数
-async function loadDocumentContent(app: App, el: HTMLElement) {
+// 提取加载文档内容的函数 - 使用 MarkdownRenderer 渲染完整内容
+async function loadDocumentContent(app: App, el: HTMLElement, markdown: string, file: TFile) {
   try {
-    const view = app.workspace.getActiveViewOfType(MarkdownView);
-    let html = "";
-    if (view) {
-      const codeMirror = view.editor.cm;
-      codeMirror.viewState.printing = true;
-      codeMirror.measure();
-      // 等待滚动操作完成
-      view.editor.scrollTo(0, 0);
-      await delay(100);
-      view.editor.scrollTo(0, Number.MAX_SAFE_INTEGER);
-      await delay(500);
-      view.editor.scrollTo(0, 0);
+    // 创建容器 div
+    const contentDiv = document.createElement('div');
+    contentDiv.className = 'markdown-preview-view markdown-rendered';
 
-      const contentDiv = view.contentEl.querySelector('.cm-content.cm-lineWrapping');
-      const tempDiv = document.createElement('div');
-      tempDiv.className = "markdown-source-view mod-cm6 is-live-preview";
-      
-      // 首先添加内容
-      tempDiv.innerHTML = contentDiv ? contentDiv.innerHTML : "";
-      
-      // 删除所有带有 cm-active class 的元素
-      tempDiv.querySelectorAll('.cm-active').forEach(el => el.classList.remove('cm-active'));
-      
-      // 删除所有 edit-block-button 和 callout-fold 元素
-      tempDiv.querySelectorAll('.edit-block-button, .callout-fold, .cm-widgetBuffer, .table-col-drag-handle, .cm-fold-indicator, .table-row-btn, .table-row-drag-handle, .table-col-btn, .table-row-drag-handle').forEach(el => el.remove());
-      
-      // 构建完整的HTML，包括样式
-      const cssStyles = `
-        <style>
-          /* 可以在这里添加更多自定义样式 */
-          /* 修复列表缩进在渲染时的问题 */
-          .export-image-root .list-bullet {
-              margin-left: -24px !important;
-          }
-          .export-image-root .cm-formatting.cm-formatting-list.cm-formatting-list-ul.cm-list-1 {
-              margin-left: 12px !important;
-          }
-          .export-image-root .list-bullet:after {
-              left: 10px !important;
-          }
-        </style>
-      `;
-      
-      // 将div的HTML和样式组合起来
-      html = `<div class="export-image-root markdown-source-view mod-cm6 is-live-preview">
-        ${cssStyles}
-        ${tempDiv.innerHTML}
-      </div>`;
-      
-      codeMirror.viewState.printing = false;
-      codeMirror.measure();
-    }
-    
+    // 获取当前视图作为渲染上下文
+    const view = app.workspace.getActiveViewOfType(MarkdownView);
+
+    // 使用 MarkdownRenderer.render() 渲染完整的 markdown 内容
+    await MarkdownRenderer.render(
+      app,
+      markdown,
+      contentDiv,
+      file.path,
+      view || new MarkdownRenderChild(contentDiv),
+    );
+
     // 设置元素内容
-    el.innerHTML = html;
-    
-    // 增加一个短暂延迟，确保页面渲染完成
-    await delay(100);
-    
-    console.log("Document content loaded:", el.innerHTML.length > 0);
-    
+    el.innerHTML = '';
+    el.appendChild(contentDiv);
+
+    // 等待图片等资源加载完成
+    await delay(200);
+
     return el;
   } catch (error) {
-    console.error("Error loading document content:", error);
+    console.error('[ExportImage] loadDocumentContent 发生错误:', error);
     return el;
   }
 }


### PR DESCRIPTION
将导出图片流程中的文档加载逻辑重构为使用 MarkdownRenderer
直接渲染完整 markdown 内容，替代之前基于编辑器 DOM 的拼接与清理。
主要改动包括：
- 新增参数 markdown 和 file 传入 loadDocumentContent，以便渲染指定文件内容。
- 在 loadDocumentContent 中创建独立的渲染容器，并调用 MarkdownRenderer.render
  渲染完整 HTML，再将其挂载到临时元素，保证样式和内嵌资源一致。
- 增加短延迟等待图片等资源加载完成，改进加载稳定性；完善错误日志前缀。
- 修复若干多余空白与格式化问题，移除 ModalContent 中无用的空行和调试日志。

为什么这样修改：
- 直接使用 MarkdownRenderer 能得到更一致、更完整的渲染结果，避免依赖编辑器
  的内部 DOM 结构和手动清理，提高兼容性和维护性。
- 通过传入具体文件和 markdown 内容，可以在快速导出（隐藏 div）和模态框
  渲染场景中复用相同逻辑，减少重复代码并降低出错概率。