### PR TITLE
feat: 增加 Obsidian 模板处理并在目标组件使用

### DIFF
--- a/src/components/common/Target.tsx
+++ b/src/components/common/Target.tsx
@@ -8,6 +8,7 @@ import { lowerCase } from 'lodash';
 import clsx from 'clsx';
 import { getRemoteImageUrl } from 'src/utils/capture';
 import { calculateSplitLines, getElementMeasures } from 'src/utils/split';
+import { processObTemplate } from 'src/utils/templates';
 
 const alignMap = {
   left: 'flex-start',
@@ -224,7 +225,7 @@ const Target = forwardRef<
                   <div className='user-info-name'>{setting.authorInfo.name}</div>
                   {setting.authorInfo.remark && (
                     <div className='user-info-remark'>
-                      {setting.authorInfo.remark}
+                      {processObTemplate(setting.authorInfo.remark)}
                     </div>
                   )}
                 </div>

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -1,0 +1,36 @@
+import { moment } from "obsidian";
+
+export function processObTemplate(Content: string) {
+    return processObTemplateInContext(Content, { moment: moment() });
+}
+
+type Context = {
+    moment: moment.Moment;
+};
+
+export function processObTemplateInContext(
+    Content: string,
+    context: Context
+) {
+    // match {{date:format}}, {{time:format}}
+    const dateFormatRegex = /{{date:(.*?)}}/g;
+    const timeFormatRegex = /{{time:(.*?)}}/g;
+    const dateRegex = /{{date}}/g;
+    const timeRegex = /{{time}}/g;
+    const momentTime = context.moment;
+
+    let res = Content.replace(dateFormatRegex, (match, format) => {
+        return momentTime.format(format?.trim() || "YYYY-MM-DD");
+    });
+    res = res.replace(timeFormatRegex, (match, format) => {
+        return momentTime.format(format?.trim() || "HH:mm");
+    });
+    res = res.replace(dateRegex, () => {
+        return momentTime.format("YYYY-MM-DD");
+    });
+    res = res.replace(timeRegex, () => {
+        return momentTime.format("HH:mm");
+    });
+
+    return res;
+}


### PR DESCRIPTION
在 utils/templates.ts 中新增模板处理函数，用于解析 Obsidian 风格的
时间/日期占位符（如 {{date}}, {{time}}, {{date:YYYY-MM-DD}} 等）。
提供 processObTemplate 和可注入上下文的 processObTemplateInContext，
方便在不同时间上下文下格式化输出。

在 Target 组件中引入并使用该函数对作者备注进行处理，
将原始文本中的模板占位符在渲染前替换为格式化后的日期/时间。
这样可以让用户在备注中直接使用日期/时间模板，提高模板化文本的
可用性和灵活性。