### PR TITLE
ci(release): 改进发布和预检工作流与版本处理

### DIFF
--- a/.github/workflows/precheck.yml
+++ b/.github/workflows/precheck.yml
@@ -1,0 +1,149 @@
+name: Version Bump Pre-check
+
+# 当PR被标记为版本更新时进行全面的预检查
+on:
+    pull_request:
+        types: [labeled, synchronize, reopened]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+env:
+    PLUGIN_ID: obsidian-plugin-starter # 替换为你的插件 ID
+
+jobs:
+    version-bump-precheck:
+        if: contains(github.event.pull_request.labels.*.name, 'version-bump')
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "18.x"
+                  cache: "npm"
+
+            - name: Prepare manifest
+              id: prepare_manifest
+              run: |
+                  if [[ ${{ github.ref }} == *"beta"* ]]; then
+                    cp manifest-beta.json manifest.json
+                  fi
+
+            - name: Install dependencies
+              run: |
+                  npm install -g yarn
+                  yarn
+
+            - name: Run comprehensive checks
+              id: checks
+              run: |
+                  echo "🔍 Starting comprehensive pre-version-bump checks..."
+
+                  # 使用与 release 一致的构建方法
+                  echo "📝 Building plugin..."
+                  if yarn run build --if-present; then
+                    echo "✅ Build successful"
+                    echo "build_check=✅" >> $GITHUB_OUTPUT
+                  else
+                    echo "❌ Build failed"
+                    echo "build_check=❌" >> $GITHUB_OUTPUT
+                    exit 1
+                  fi
+
+                  # 构建产物检查
+                  echo "📦 Verifying build artifacts..."
+                  required_files=("main.js" "manifest.json" "styles.css")
+                  missing_files=()
+
+                  for file in "${required_files[@]}"; do
+                    if [ ! -f "$file" ]; then
+                      missing_files+=("$file")
+                    fi
+                  done
+
+                  if [ ${#missing_files[@]} -eq 0 ]; then
+                    echo "✅ All required build artifacts found"
+                    echo "artifacts_check=✅" >> $GITHUB_OUTPUT
+                  else
+                    echo "❌ Missing build artifacts: ${missing_files[*]}"
+                    echo "artifacts_check=❌" >> $GITHUB_OUTPUT
+                    exit 1
+                  fi
+
+                  # 版本一致性检查
+                  echo "🔢 Checking version consistency..."
+                  package_version=$(node -p "require('./package.json').version")
+                  manifest_version=$(node -p "require('./manifest.json').version")
+
+                  echo "Package.json version: $package_version"
+                  echo "Manifest.json version: $manifest_version"
+
+                  if [ "$package_version" = "$manifest_version" ]; then
+                    echo "✅ Version consistency check passed"
+                    echo "version_check=✅" >> $GITHUB_OUTPUT
+                  else
+                    echo "❌ Version mismatch between package.json and manifest.json"
+                    echo "version_check=❌" >> $GITHUB_OUTPUT
+                    exit 1
+                  fi
+
+            - name: Generate check report
+              if: always()
+              run: |
+                  echo "📊 Pre-version-bump Check Report"
+                  echo "================================="
+                  echo "Build: ${{ steps.checks.outputs.build_check }}"
+                  echo "Build Artifacts: ${{ steps.checks.outputs.artifacts_check }}"
+                  echo "Version Consistency: ${{ steps.checks.outputs.version_check }}"
+
+            - name: Find previous precheck comment
+              if: always()
+              uses: peter-evans/find-comment@v3
+              id: fc
+              with:
+                  issue-number: ${{ github.event.pull_request.number }}
+                  comment-author: "github-actions[bot]"
+                  body-includes: "## Version Bump Pre-check"
+
+            - name: Create or update success comment
+              if: success()
+              uses: peter-evans/create-or-update-comment@v4
+              with:
+                  comment-id: ${{ steps.fc.outputs.comment-id }}
+                  issue-number: ${{ github.event.pull_request.number }}
+                  body: |
+                      ## Version Bump Pre-check Passed!
+
+                      All checks have completed successfully. This PR is ready for version bump.
+
+                      ### Check Results:
+                      - ${{ steps.checks.outputs.build_check }} Build & Compilation
+                      - ${{ steps.checks.outputs.artifacts_check }} Build Artifacts
+                      - ${{ steps.checks.outputs.version_check }} Version Consistency
+
+                      You can now safely proceed with version bump and release.
+
+            - name: Create or update failure comment
+              if: failure()
+              uses: peter-evans/create-or-update-comment@v4
+              with:
+                  comment-id: ${{ steps.fc.outputs.comment-id }}
+                  issue-number: ${{ github.event.pull_request.number }}
+                  body: |
+                      ## Version Bump Pre-check Failed!
+
+                      Some checks have failed. Please review and fix the issues before proceeding with version bump.
+
+                      ### Check Results:
+                      - ${{ steps.checks.outputs.build_check || '❓' }} Build & Compilation
+                      - ${{ steps.checks.outputs.artifacts_check || '❓' }} Build Artifacts
+                      - ${{ steps.checks.outputs.version_check || '❓' }} Version Consistency
+
+                      Please check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for detailed error information.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,34 +1,80 @@
 name: Release Obsidian plugin
 
 on:
-  push:
-    tags:
-      - "*"
+    push:
+        tags:
+            - "[0-9]+.[0-9]+.[0-9]+*" # 匹配类似 1.0.0 或 1.0.0-beta.1 的格式
+
+permissions:
+    contents: write
+    discussions: write
+
+env:
+    PLUGIN_ID: obsidian-plugin-starter # 插件ID
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+    build:
+        runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v3
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0 # 获取完整的git历史
 
-      - name: Use Node.js
-        uses: actions/setup-node@v4.1.0
-        with:
-          node-version: "22.x"
+            - name: Use Node.js
+              uses: actions/setup-node@v3
+              with:
+                  node-version: "22.x"
 
-      - name: Build plugin
-        run: |
-          npm install -g pnpm
-          pnpm install
-          pnpm build
+            - name: Prepare manifest
+              id: prepare_manifest
+              run: |
+                  if [[ ${{ github.ref }} == *"beta"* ]]; then
+                    cp manifest-beta.json manifest.json
+                  fi
 
-      - name: Create release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          tag="${GITHUB_REF#refs/tags/}"
+            - name: Build
+              id: build
+              run: |
+                  npm install -g pnpm
+                  pnpm install
+                  pnpm build
+                  
+                  # 检查 styles.css 是否存在
+                  if [ -f "styles.css" ]; then
+                    echo "✅ styles.css found"
+                    echo "has_styles=true" >> $GITHUB_OUTPUT
+                  else
+                    echo "⚠️ styles.css not found, will be skipped in release"
+                    echo "has_styles=false" >> $GITHUB_OUTPUT
+                  fi
+                  
+                  # 打包插件目录
+                  mkdir ${{ env.PLUGIN_ID }}
+                  cp main.js manifest.json ${{ env.PLUGIN_ID }}
+                  [ -f "styles.css" ] && cp styles.css ${{ env.PLUGIN_ID }}
+                  zip -r ${{ env.PLUGIN_ID }}-${{ github.ref_name }}.zip ${{ env.PLUGIN_ID }}
+                  ls -la
+                  echo "tag_name=$(git tag --sort version:refname | tail -n 1)" >> $GITHUB_OUTPUT
 
-          gh release create "$tag" \
-            --title="$tag" \
-            main.js manifest.json styles.css
+            - name: Create Release
+              id: create_release
+              uses: softprops/action-gh-release@v2
+              with:
+                  tag_name: ${{ github.ref_name }}
+                  name: ${{ github.ref_name }}
+                  draft: false
+                  prerelease: ${{ contains(github.ref, 'beta') }}
+                  generate_release_notes: true
+                  discussion_category_name: "Announcements"
+                  body: |
+                      ${{ contains(github.ref, 'beta') && '🚧 This is a beta release' || '🎉 This is a stable release' }}
+
+                      **Version:** ${{ github.ref_name }}
+                  files: |
+                      ${{ env.PLUGIN_ID }}-${{ github.ref_name }}.zip
+                      main.js
+                      manifest.json
+                      ${{ steps.build.outputs.has_styles == 'true' && 'styles.css' || '' }}
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
更新发布工作流以增强自动化和兼容性，添加预检工作流用于版本提升质量控制。主要改变包括：
- 将 release workflow 的触发规则改为仅匹配语义化标签（如 1.0.0 / 1.0.0-beta.1），并增加写权限与环境变量（PLUGIN_ID）。
- 升级并规范 actions（checkout -> v4、setup-node -> v3），确保获取完整 git 历史并使用稳定的 Node 版本。
- 在构建步骤中加入预处理 manifest（根据 beta 分支替换 manifest-beta.json）、构建后检查 styles.css、按插件目录打包为 zip，并将构建输出通过 GitHub Actions 输出变量传递给发布步骤。
- 使用 softprops/action-gh-release 创建 Release，支持草稿/预发布、自动生成 release notes，并将附件（zip、main.js、manifest.json、有条件的 styles.css）上传到发布中。
- 添加 precheck workflow，在 PR 被标记为 version-bump 时触发，执行 checkout、Node 环境准备、依赖安装和一致性的构建/检查步骤，以在合并前捕获问题。