### PR TITLE
feat: 优化 CSS 加载与兼容性更新

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"id": "obsidian-export-image-fork",
 	"name": "Export Image plugin (Fork)",
 	"version": "0.0.2",
-	"minAppVersion": "1.4.0",
+	"minAppVersion": "1.8.0",
 	"description": "Easily convert your article to image.",
 	"author": "Zhou Hua & RavenHogwarts",
 	"authorUrl": "",

--- a/src/components/common/Target.tsx
+++ b/src/components/common/Target.tsx
@@ -164,7 +164,7 @@ const Target = forwardRef<
       >
         <Watermark {...watermarkProps}>
           <div
-            className='markdown-preview-view markdown-rendered export-image-preview-container'
+            className='export-image-preview-container'
             style={{
               width: `${setting.width}px`,
               transition: 'width 0.25s',

--- a/src/components/file/ModalContent.tsx
+++ b/src/components/file/ModalContent.tsx
@@ -306,13 +306,35 @@ const ModalContent: FC<{
 
   useEffect(() => {
     const cssPath = formData.customCSS?.css;
-    if (cssPath) {
-      readCSSFile(app, cssPath).then(content => {
-        setCustomCSSContent(content);
-      }).catch(console.error);
-    } else {
-      setCustomCSSContent('');
-    }
+
+    // 读取 CSS 文件内容的辅助函数
+    const loadCSSContent = () => {
+      if (cssPath) {
+        readCSSFile(app, cssPath).then(content => {
+          setCustomCSSContent(content);
+        }).catch(console.error);
+      } else {
+        setCustomCSSContent('');
+      }
+    };
+
+    // 初始加载
+    loadCSSContent();
+
+    // 监听文件修改事件，当选中的 CSS 文件内容变化时实时更新
+    const handleFileModify = (file: { path: string }) => {
+      if (file.path === cssPath) {
+        loadCSSContent();
+      }
+    };
+
+    // 注册事件监听
+    const eventRef = app.vault.on('modify', handleFileModify);
+
+    // 清理函数：取消事件监听
+    return () => {
+      app.vault.offref(eventRef);
+    };
   }, [app, formData.customCSS?.css]);
 
   const handleSave = useCallback(async () => {


### PR DESCRIPTION
在 ModalContent 中重构 CSS 文件读取逻辑，抽离为 loadCSSContent
函数并添加文件修改监听，确保当选中的 CSS 文件被修改时能实时
刷新显示内容。同时在组件卸载时取消事件监听，避免内存泄漏或
多次注册监听器的问题。修复原代码中注册/注销事件的可读性与
鲁棒性。

更新 manifest.json 的最低应用版本要求从 1.4.0 提升到 1.8.0，
以兼容使用的 API 更改或新增特性。

简化预览容器的 class 名称，去掉多余的 markdown-preview-view
和 markdown-rendered 类，统一使用 export-image-preview-container，
以便样式管理更清晰、避免样式冲突。