### PR TITLE
style: 美化导出预览区域滚动与高度控制

### DIFF
--- a/src/components/file/ModalContent.tsx
+++ b/src/components/file/ModalContent.tsx
@@ -445,7 +445,12 @@ const ModalContent: FC<{
   return (
     <div className="export-image-preview-root">
       <div className="export-image-preview-main">
-        <div className="export-image-preview-left">
+        <div
+          className="export-image-preview-left"
+          style={
+            { "--preview-height": `${mainHeight}px` } as React.CSSProperties
+          }
+        >
           <FormItems
             formSchema={formSchema}
             update={setFormData}

--- a/styles/FileModalContent.css
+++ b/styles/FileModalContent.css
@@ -66,6 +66,26 @@
   font-size: 14px;
   line-height: 28px;
   box-sizing: border-box;
+  max-height: var(--preview-height, 539px);
+  scrollbar-gutter: stable;
+
+  /* 美化滚动条 */
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--background-modifier-border);
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--background-modifier-border-hover);
+  }
 
   .setting-item {
     padding: 10px 0 !important;


### PR DESCRIPTION
添加导出预览内容的最大高度和自定义滚动条样式，确保在内容较
多时界面保持稳定且外观更一致。通过 CSS 设定 max-height、scrollbar-gutter
以及针对 WebKit 的滚动条轨道与拇柄样式（包括 hover 状态），改善在各
种主题下的视觉效果与可用性。

在组件中通过内联 style 注入 --preview-height 变量，使用计算后的
mainHeight 动态控制预览区域高度，确保样式与运行时布局同步。