### PR TITLE
feat(i18n): 用 Obsidian API 获取当前语言

### DIFF
--- a/src/i18n/L.ts
+++ b/src/i18n/L.ts
@@ -1,3 +1,4 @@
+import { getLanguage } from "obsidian";
 import { type Locales } from "./i18n-types";
 import { baseLocale, i18n, locales } from "./i18n-util";
 import { loadAllLocales } from "./i18n-util.sync";
@@ -7,7 +8,7 @@ loadAllLocales();
 let locale: Locales = "en";
 try {
   // @ts-ignore
-  locale = (global?.i18next?.language as string) || "";
+  locale = getLanguage();
   if (locale.startsWith("zh")) {
     locale = "zh";
   }


### PR DESCRIPTION
将直接从全局对象读取 i18next 语言的逻辑替换为使用
Obsidian 提供的 getLanguage() 接口。主要变更：
- 引入 getLanguage 并用其返回值初始化 locale。
- 移除对 global?.i18next?.language 的依赖。

这样做的原因：
- 使用官方 API 更稳定可靠，避免依赖全局变量结构变化或不可用情形。
- 提高在不同运行环境下获取语言的兼容性和可维护性。