### PR TITLE
feat: 更改设置页图标为更直观的图像图标

### DIFF
--- a/src/settings/SettingsTab.tsx
+++ b/src/settings/SettingsTab.tsx
@@ -7,7 +7,7 @@ import SettingPage from "./SettingPage";
 export default class ImageSettingTab extends PluginSettingTab {
   plugin: ExportImagePlugin;
   root: Root | null = null;
-  icon: string = "square-dashed-bottom-code";
+  icon: string = "image-upscale";
 
   constructor(app: App, plugin: ExportImagePlugin) {
     super(app, plugin);


### PR DESCRIPTION
将 SettingsTab 中的 icon 从 "square-dashed-bottom-code"
替换为 "image-upscale"。目的是使设置界面使用更符合
功能语义的图标，提升用户对图像导出/放大相关设置的
识别性与可用性。