### PR TITLE
fix: 修复导出图片内联标题的显示问题

### DIFF
--- a/styles/FileModalContent.css
+++ b/styles/FileModalContent.css
@@ -1,3 +1,9 @@
+body:not(.show-inline-title)
+  .export-image-root
+  .inline-title:not([data-level]) {
+  display: block !important;
+}
+
 .export-image-root {
   &.markdown-reading-view {
     container-type: normal !important;


### PR DESCRIPTION
在导出图片的样式中添加规则，确保在非内联标题模式下
没有 data-level 的 .inline-title 元素强制显示为块级元素。
这样可以修复在某些布局下标题被隐藏的问题，保证导出图像
中的标题按预期呈现并避免布局错位。