### PR TITLE
feat: 默认使用自定义文件名显示逻辑

### DIFF
--- a/src/components/file/exportImage.tsx
+++ b/src/components/file/exportImage.tsx
@@ -45,7 +45,7 @@ export default async function (
         setting={{
           ...settings,
           showMetadata: false,
-          showFilename: { mode: "none" },
+          showFilename: { mode: "custom", customTitle: "" },
           split: { overlap: 0, height: 0, mode: "none" },
         }}
         frontmatter={{}}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -4,8 +4,7 @@ import { isCreatable } from "../imageFormatTester";
 export const DEFAULT_SETTINGS: ISettings = {
   width: 640,
   showFilename: {
-    mode: "frontmatter",
-    frontmatterProperty: "title",
+    mode: "custom",
   },
   // eslint-disable-next-line @typescript-eslint/naming-convention
   resolutionMode: "3x" as ResolutionMode,


### PR DESCRIPTION
将配置中 showFilename 的默认模式从 frontmatter 改为 custom，
并在导出组件中确保当不显示元数据时仍传递自定义标题字段。

为什么做此改动：
- 统一默认行为为自定义模式，避免依赖 frontmatter 存在与否带来不确定性。
- 导出时明确提供 customTitle 字段（即使为空），防止组件接收到缺失的结构导致渲染或类型处理异常。

重要改动概览：
- 默认设置 DEFAULT_SETTINGS.showFilename.mode 从 "frontmatter"
  改为 "custom"。
- exportImage 组件在不显示元数据时将 showFilename 设为
  { mode: "custom", customTitle: "" }，保证数据结构一致。